### PR TITLE
PCIE-213 TLP getBitRep unit tests

### DIFF
--- a/PCIe 6.0 Packet Generator and Exerciser/Google Test/Google Test.vcxproj
+++ b/PCIe 6.0 Packet Generator and Exerciser/Google Test/Google Test.vcxproj
@@ -40,6 +40,7 @@
     <ClCompile Include="configuration_controller_unittest.cpp" />
     <ClCompile Include="configuration_space_unittest.cpp" />
     <ClCompile Include="pcie_capability_structure_unittest.cpp" />
+    <ClCompile Include="layers_tlp_unittest.cpp" />
     <ClCompile Include="test.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/PCIe 6.0 Packet Generator and Exerciser/Google Test/layers_tlp_unittest.cpp
+++ b/PCIe 6.0 Packet Generator and Exerciser/Google Test/layers_tlp_unittest.cpp
@@ -10,3 +10,127 @@ TEST(TLPGetBitRep, OHCA1firstDWBE) {
 		EXPECT_EQ(bitRep.to_ulong(), i);
 	}
 }
+
+TEST(TLPGetBitRep, OHCA1lastDWBE) {
+	OHCA1* ohc = new OHCA1(std::bitset<4>(), std::bitset<4>());
+	for (int i = 0; i < 16; i++) {
+		ohc->lastDWBE = i;
+		boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+		bitRep.operator=(bitRep.operator>>(4));
+		bitRep.resize(4);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, OHCA1FullPacket) {
+	OHCA1* ohc = new OHCA1(std::bitset<4>(9), std::bitset<4>(7));
+	ohc->firstDWBE = 9;
+	ohc->lastDWBE = 7;
+	boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+	EXPECT_EQ(bitRep.to_ulong(), 0x79);
+}
+
+TEST(TLPGetBitRep, OHCA3firstDWBE) {
+	OHCA3* ohc = new OHCA3(std::bitset<4>(), std::bitset<4>(), 0);
+	for (int i = 0; i < 16; i++) {
+		ohc->firstDWBE = i;
+		boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+		bitRep.resize(4);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, OHCA3lastDWBE) {
+	OHCA3* ohc = new OHCA3(std::bitset<4>(), std::bitset<4>(), 0);
+	for (int i = 0; i < 16; i++) {
+		ohc->lastDWBE = i;
+		boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+		bitRep.operator=(bitRep.operator>>(4));
+		bitRep.resize(4);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, OHCA3destinationSegment) {
+	OHCA3* ohc = new OHCA3(std::bitset<4>(), std::bitset<4>(), 0);
+	for (int i = 0; i < 256; i++) {
+		ohc->destinationSegment = i;
+		boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+		bitRep.operator=(bitRep.operator>>(24));
+		bitRep.resize(8);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, OHCA3FullPacket) {
+	OHCA3* ohc = new OHCA3(std::bitset<4>(9), std::bitset<4>(7), 186);
+	boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+	EXPECT_EQ(bitRep.to_ulong(), 0xBA000079);
+}
+
+TEST(TLPGetBitRep, OHCA4destinationSegment) {
+	OHCA4* ohc = new OHCA4(0);
+	for (int i = 0; i < 256; i++) {
+		ohc->destinationSegment = i;
+		boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+		bitRep.operator=(bitRep.operator>>(24));
+		bitRep.resize(8);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, OHCA4FullPacket) {
+	OHCA4* ohc = new OHCA4(186);
+	boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+	EXPECT_EQ(bitRep.to_ulong(), 0xBA000000);
+}
+
+TEST(TLPGetBitRep, OHCA5cplStatus) {
+	OHCA5* ohc = new OHCA5(0, 0, std::bitset<2>(), OHCA5::CPLStatus::True);
+	boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+	bitRep.resize(3);
+	EXPECT_EQ(bitRep.to_ulong(), 1);
+	ohc->CPLStatusEnum = OHCA5::CPLStatus::False;
+	bitRep = ohc->getBitRep();
+	bitRep.resize(3);
+	EXPECT_EQ(bitRep.to_ulong(), 0);
+}
+
+TEST(TLPGetBitRep, OHCA5lowerAddress) {
+	OHCA5* ohc = new OHCA5(0, 0, std::bitset<2>(), OHCA5::CPLStatus::True);
+	for (int i = 0; i < 4; i++) {
+		ohc->lowerAddress = i;
+		boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+		bitRep.operator=(bitRep.operator>>(3));
+		bitRep.resize(2);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, OHCA5completerSegment) {
+	OHCA5* ohc = new OHCA5(0, 0, std::bitset<2>(), OHCA5::CPLStatus::True);
+	for (int i = 0; i < 256; i++) {
+		ohc->completerSegment = i;
+		boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+		bitRep.operator=(bitRep.operator>>(16));
+		bitRep.resize(8);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, OHCA5destinationSegment) {
+	OHCA5* ohc = new OHCA5(0, 0, std::bitset<2>(), OHCA5::CPLStatus::True);
+	for (int i = 0; i < 256; i++) {
+		ohc->destinationSegment = i;
+		boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+		bitRep.operator=(bitRep.operator>>(24));
+		bitRep.resize(8);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, OHCA5FullPacket) {
+	OHCA5* ohc = new OHCA5(91, 249, std::bitset<2>(1), OHCA5::CPLStatus::True);
+	boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+	EXPECT_EQ(bitRep.to_ulong(), 0x5BF90009);
+}

--- a/PCIe 6.0 Packet Generator and Exerciser/Google Test/layers_tlp_unittest.cpp
+++ b/PCIe 6.0 Packet Generator and Exerciser/Google Test/layers_tlp_unittest.cpp
@@ -1,0 +1,12 @@
+#include "pch.h"
+#include "../PCIe 6.0 Packet Generator and Exerciser/utils/tlp.h"
+
+TEST(TLPGetBitRep, OHCA1firstDWBE) {
+	OHCA1* ohc = new OHCA1(std::bitset<4>(), std::bitset<4>());
+	for (int i = 0; i < 16; i++) {
+		ohc->firstDWBE = i;
+		boost::dynamic_bitset<> bitRep = ohc->getBitRep();
+		bitRep.resize(4);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}

--- a/PCIe 6.0 Packet Generator and Exerciser/Google Test/layers_tlp_unittest.cpp
+++ b/PCIe 6.0 Packet Generator and Exerciser/Google Test/layers_tlp_unittest.cpp
@@ -134,3 +134,300 @@ TEST(TLPGetBitRep, OHCA5FullPacket) {
 	boost::dynamic_bitset<> bitRep = ohc->getBitRep();
 	EXPECT_EQ(bitRep.to_ulong(), 0x5BF90009);
 }
+
+TEST(TLPGetBitRep, NonHeaderAddress32Address) {
+	AddressRouting32Bit* nha = new AddressRouting32Bit(0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 30-bit number
+		int random = rand() % 1073741824;
+		nha->address = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(2));
+		bitRep.resize(30);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderAddress32Tag) {
+	AddressRouting32Bit* nha = new AddressRouting32Bit(0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 14-bit number
+		int random = rand() % 16384;
+		nha->tag = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(32));
+		bitRep.resize(14);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderAddress32RequesterID) {
+	AddressRouting32Bit* nha = new AddressRouting32Bit(0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 16-bit number
+		int random = rand() % 65536;
+		nha->requestID = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(48));
+		bitRep.resize(16);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderAddress32FullPacket) {
+	AddressRouting32Bit* nha = new AddressRouting32Bit(48169, 10254, 73741824);
+	boost::dynamic_bitset<> bitRep = nha->getBitRep();
+	boost::dynamic_bitset<> bitRep2(bitRep.operator>>(32));
+	bitRep2.resize(32);
+	bitRep.resize(32);
+	EXPECT_EQ(bitRep2.to_ulong(), 0xBC29280E);
+	EXPECT_EQ(bitRep.to_ulong(), 0x1194D800);
+}
+
+TEST(TLPGetBitRep, NonHeaderAddress64Address) {
+	AddressRouting64Bit* nha = new AddressRouting64Bit(0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 62-bit number
+		long long random = rand() % 4611686018427387904;
+		nha->address = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(2));
+		bitRep.resize(62);
+		long long lower = random & 0x3FFFFFFF;
+		long long upper = random >> 30;
+		boost::dynamic_bitset<> bitRep2(bitRep);
+		bitRep2.resize(30);
+		boost::dynamic_bitset<> bitRep3(bitRep.operator>>(30));
+		bitRep3.resize(32);
+		EXPECT_EQ(bitRep2.to_ulong(), lower);
+		EXPECT_EQ(bitRep3.to_ulong(), upper);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderAddress64Tag) {
+	AddressRouting64Bit* nha = new AddressRouting64Bit(0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 14-bit number
+		int random = rand() % 16384;
+		nha->tag = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(64));
+		bitRep.resize(14);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderAddress64RequesterID) {
+	AddressRouting64Bit* nha = new AddressRouting64Bit(0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 16-bit number
+		int random = rand() % 65536;
+		nha->requestID = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(80));
+		bitRep.resize(16);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderAddress64FullPacket) {
+	AddressRouting64Bit* nha = new AddressRouting64Bit(48169, 10254, 4294967297);
+	boost::dynamic_bitset<> bitRep = nha->getBitRep();
+	boost::dynamic_bitset<> bitRep2(bitRep.operator>>(32));
+	boost::dynamic_bitset<> bitRep3(bitRep.operator>>(64));
+	bitRep.resize(32);
+	bitRep2.resize(32);
+	bitRep3.resize(32);
+	EXPECT_EQ(bitRep3.to_ulong(), 0xBC29280E);
+	EXPECT_EQ(bitRep2.to_ulong(), 0x00000001);
+	EXPECT_EQ(bitRep.to_ulong(), 0x00000004);
+}
+
+TEST(TLPGetBitRep, NonHeaderConfigRegisterNumber) {
+	ConfigNonHeaderBase* nha = new ConfigNonHeaderBase(0, 0, 0, 0, 0, 0);
+	for (int i = 0; i <1024; i++) {
+		nha->registerNumber = i;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(2));
+		bitRep.resize(10);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderConfigBusNumber) {
+	ConfigNonHeaderBase* nha = new ConfigNonHeaderBase(0, 0, 0, 0, 0, 0);
+	for (int i = 0; i < 256; i++) {
+		nha->busNumber = i;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(24));
+		bitRep.resize(8);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderConfigDeviceNumber) {
+	ConfigNonHeaderBase* nha = new ConfigNonHeaderBase(0, 0, 0, 0, 0, 0);
+	for (int i = 0; i < 32; i++) {
+		nha->deviceNumber = i;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(19));
+		bitRep.resize(5);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderConfigFunctionNumber) {
+	ConfigNonHeaderBase* nha = new ConfigNonHeaderBase(0, 0, 0, 0, 0, 0);
+	for (int i = 0; i < 8; i++) {
+		nha->functionNumber = i;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(16));
+		bitRep.resize(3);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderConfigTag) {
+	ConfigNonHeaderBase* nha = new ConfigNonHeaderBase(0, 0, 0, 0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 14-bit number
+		int random = rand() % 16384;
+		nha->tag = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(32));
+		bitRep.resize(14);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderConfigRequesterID) {
+	ConfigNonHeaderBase* nha = new ConfigNonHeaderBase(0, 0, 0, 0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 16-bit number
+		int random = rand() % 65536;
+		nha->requestID = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(48));
+		bitRep.resize(16);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderMessageMessageCode) {
+	MessageNonHeaderBase* nha = new MessageNonHeaderBase(0, 0);
+	for (int i = 0; i < 256; i++) {
+		nha->messageCode = i;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(64));
+		bitRep.resize(8);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderMessageRequesterID) {
+	MessageNonHeaderBase* nha = new MessageNonHeaderBase(0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 16-bit number
+		int random = rand() % 65536;
+		nha->requestID = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(80));
+		bitRep.resize(16);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderCompletionByteCount) {
+	CompletionNonHeaderBase* nha = new CompletionNonHeaderBase(0, 0, 0, 0, 0, 0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 12-bit number
+		long random = rand() % 4096;
+		nha->byteCount = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.resize(12);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderCompletionLowerAddress) {
+	CompletionNonHeaderBase* nha = new CompletionNonHeaderBase(0, 0, 0, 0, 0, 0, 0, 0);
+	for (int i = 0; i < 32; i++) {
+		nha->lowerAddress = i;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		EXPECT_EQ(bitRep[46], i >> 4);
+		bitRep.operator=(bitRep.operator>>(12));
+		bitRep.resize(4);
+		EXPECT_EQ(bitRep.to_ulong(), i & 0xF);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderCompletionBusNumber) {
+	CompletionNonHeaderBase* nha = new CompletionNonHeaderBase(0, 0, 0, 0, 0, 0, 0, 0);
+	for (int i = 0; i < 256; i++) {
+		nha->busNumber = i;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(24));
+		bitRep.resize(8);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderCompletionDeviceNumber) {
+	CompletionNonHeaderBase* nha = new CompletionNonHeaderBase(0, 0, 0, 0, 0, 0, 0, 0);
+	for (int i = 0; i < 32; i++) {
+		nha->deviceNumber = i;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(19));
+		bitRep.resize(5);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderCompletionFunctionNumber) {
+	CompletionNonHeaderBase* nha = new CompletionNonHeaderBase(0, 0, 0, 0, 0, 0, 0, 0);
+	for (int i = 0; i < 8; i++) {
+		nha->functionNumber = i;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(16));
+		bitRep.resize(3);
+		EXPECT_EQ(bitRep.to_ulong(), i);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderCompletionTag) {
+	CompletionNonHeaderBase* nha = new CompletionNonHeaderBase(0, 0, 0, 0, 0, 0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 14-bit number
+		int random = rand() % 16384;
+		nha->tag = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(32));
+		bitRep.resize(14);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}
+
+TEST(TLPGetBitRep, NonHeaderCompletionCompleterID) {
+	CompletionNonHeaderBase* nha = new CompletionNonHeaderBase(0, 0, 0, 0, 0, 0, 0, 0);
+	srand(1);
+	for (int i = 0; i < 256; i++) {
+		// generate random 16-bit number
+		int random = rand() % 65536;
+		nha->completerID = random;
+		boost::dynamic_bitset<> bitRep = nha->getBitRep();
+		bitRep.operator=(bitRep.operator>>(48));
+		bitRep.resize(16);
+		EXPECT_EQ(bitRep.to_ulong(), random);
+	}
+}

--- a/PCIe 6.0 Packet Generator and Exerciser/Google Test/layers_tlp_unittest.cpp
+++ b/PCIe 6.0 Packet Generator and Exerciser/Google Test/layers_tlp_unittest.cpp
@@ -537,20 +537,24 @@ TEST(TLPGetBitRep, TLPFullPacketNoDatapayload) {
 	h->lengthInDoubleWord = 0;
 	h->OHC = 26;
 	h->TC = 0;
+	OHCA3* ohc = new OHCA3(std::bitset<4>(9), std::bitset<4>(7), 186);
+	h->OHCVector.push_back(ohc);
 	h->nonBase = new AddressRouting64Bit(48169, 10254, 4294967297);
 	tlp->header = h;
 	boost::dynamic_bitset<> bitRep = tlp->getBitRep();
 	boost::dynamic_bitset<> bitRep2(bitRep.operator>>(32));
 	boost::dynamic_bitset<> bitRep3(bitRep.operator>>(64));
 	boost::dynamic_bitset<> bitRep4(bitRep.operator>>(96));
+	boost::dynamic_bitset<> bitRep5(bitRep.operator>>(128));
 	bitRep.resize(32);
 	bitRep2.resize(32);
 	bitRep3.resize(32);
 	bitRep4.resize(32);
-	EXPECT_EQ(bitRep4.to_ulong(), 0x201A0000);
-	EXPECT_EQ(bitRep3.to_ulong(), 0xBC29280E);
-	EXPECT_EQ(bitRep2.to_ulong(), 0x00000001);
-	EXPECT_EQ(bitRep.to_ulong(), 0x00000004);
+	EXPECT_EQ(bitRep5.to_ulong(), 0x201A0000);
+	EXPECT_EQ(bitRep4.to_ulong(), 0xBC29280E);
+	EXPECT_EQ(bitRep3.to_ulong(), 0x00000001);
+	EXPECT_EQ(bitRep2.to_ulong(), 0x00000004);
+	EXPECT_EQ(bitRep.to_ulong(), 0xBA000079);
 }
 
 TEST(TLPGetBitRep, TLPFullPacketWithDatapayload) {
@@ -560,6 +564,8 @@ TEST(TLPGetBitRep, TLPFullPacketWithDatapayload) {
 	h->lengthInDoubleWord = 2;
 	h->OHC = 26;
 	h->TC = 0;
+	OHCA3* ohc = new OHCA3(std::bitset<4>(9), std::bitset<4>(7), 186);
+	h->OHCVector.push_back(ohc);
 	h->nonBase = new AddressRouting64Bit(48169, 10254, 4294967297);
 	tlp->header = h;
 	tlp->dataPayload = boost::dynamic_bitset<>(64, 0x00000001);
@@ -570,16 +576,18 @@ TEST(TLPGetBitRep, TLPFullPacketWithDatapayload) {
 	boost::dynamic_bitset<> bitRep4(bitRep.operator>>(96));
 	boost::dynamic_bitset<> bitRep5(bitRep.operator>>(128));
 	boost::dynamic_bitset<> bitRep6(bitRep.operator>>(160));
+	boost::dynamic_bitset<> bitRep7(bitRep.operator>>(192));
 	bitRep.resize(32);
 	bitRep2.resize(32);
 	bitRep3.resize(32);
 	bitRep4.resize(32);
 	bitRep5.resize(32);
 	bitRep6.resize(32);
-	EXPECT_EQ(bitRep6.to_ulong(), 0x601A030D);
-	EXPECT_EQ(bitRep5.to_ulong(), 0xBC29280E);
-	EXPECT_EQ(bitRep4.to_ulong(), 0x00000001);
-	EXPECT_EQ(bitRep3.to_ulong(), 0x00000004);
+	EXPECT_EQ(bitRep7.to_ulong(), 0x601A0002);
+	EXPECT_EQ(bitRep6.to_ulong(), 0xBC29280E);
+	EXPECT_EQ(bitRep5.to_ulong(), 0x00000001);
+	EXPECT_EQ(bitRep4.to_ulong(), 0x00000004);
+	EXPECT_EQ(bitRep3.to_ulong(), 0xBA000079);
 	EXPECT_EQ(bitRep2.to_ulong(), 0x00000001);
 	EXPECT_EQ(bitRep.to_ulong(), 0x00000001);
 }

--- a/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/non_header_base.cpp
+++ b/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/non_header_base.cpp
@@ -109,20 +109,18 @@ NonHeaderBase* ConfigNonHeaderBase::getObjRep(boost::dynamic_bitset<> bitset) {
 boost::dynamic_bitset<> CompletionNonHeaderBase::getBitRep() const {
     boost::dynamic_bitset<> result((headerSizeInBytes * 8) - 32);
 
-    std::bitset<6> myBitset(lowerAddress);  // convert integer to bitset
+    std::bitset<5> myBitset(lowerAddress);  // convert integer to bitset
 
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, byteCount));
     //Add the lowerAddress
-    int y = 2;
     for (int i = 0; i < 4; i++) {
-        result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, myBitset[y] << (12 + i)));
-        y++;
+        result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, myBitset[i] << (12 + i)));
     }
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, functionNumber) << 16);
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, deviceNumber) << 19);
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, busNumber) << 24);
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, tag) << 32);
-    result[46] = myBitset[5];
+    result[46] = myBitset[4];
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, completerID) << 48);
 
     return result;

--- a/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/non_header_base.cpp
+++ b/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/non_header_base.cpp
@@ -5,7 +5,7 @@
 
 boost::dynamic_bitset<> AddressRouting32Bit::getBitRep() const {
     boost::dynamic_bitset<> result ((headerSizeInBytes * 8) - 32) ;
-    result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, address));
+    result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, address) << 2);
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, tag) << 32);
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, requestID) << 48);
     return result;
@@ -29,7 +29,8 @@ NonHeaderBase* AddressRouting32Bit::getObjRep(boost::dynamic_bitset<> bitset){
 
 boost::dynamic_bitset<> AddressRouting64Bit::getBitRep() const {
     boost::dynamic_bitset<> result ((headerSizeInBytes * 8) - 32) ;
-    result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, address));
+    result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, address) << 2);
+    result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, address >> 32) << 32);
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, tag) << 64);
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, requestID) << 80);
     return result;
@@ -109,9 +110,7 @@ boost::dynamic_bitset<> CompletionNonHeaderBase::getBitRep() const {
     boost::dynamic_bitset<> result((headerSizeInBytes * 8) - 32);
 
     std::bitset<6> myBitset(lowerAddress);  // convert integer to bitset
-    std::bitset<1> lastBit;  // bitset to hold last 1 bits
 
-    lastBit[0] = myBitset[5];
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, byteCount));
     //Add the lowerAddress
     int y = 2;
@@ -123,7 +122,7 @@ boost::dynamic_bitset<> CompletionNonHeaderBase::getBitRep() const {
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, deviceNumber) << 19);
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, busNumber) << 24);
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, tag) << 32);
-    result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, lastBit[0]) << 46);
+    result[46] = myBitset[5];
     result |= (boost::dynamic_bitset<>((headerSizeInBytes * 8) - 32, completerID) << 48);
 
     return result;

--- a/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/tlp.cpp
+++ b/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/tlp.cpp
@@ -10,9 +10,14 @@ int TLP::getTotalLength() {
 }
 
 boost::dynamic_bitset<> TLP::getBitRep() {
-	boost::dynamic_bitset<> result(getTotalLength() * 8);
-	result |= (dataPayload);
-	result |= ((boost::dynamic_bitset<>((header->getBitRep())) << getTotalLength()));
+	int totalLength = getTotalLength() * 8;
+	boost::dynamic_bitset<> result(totalLength);
+	boost::dynamic_bitset<> dataPayloadCopy = dataPayload;
+	dataPayloadCopy.resize(totalLength);
+	result |= dataPayloadCopy;
+	boost::dynamic_bitset<> headerCopy = header->getBitRep();
+	headerCopy.resize(totalLength);
+	result |= (headerCopy << dataPayload.size());
 
 	return result;
 }

--- a/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/tlp_header.cpp
+++ b/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/tlp_header.cpp
@@ -19,7 +19,7 @@ boost::dynamic_bitset<> TLPHeader::getBitRep() const {
     for (int i = 0; i < OHCVector.size(); i++) {
         boost::dynamic_bitset<> OHC_header = OHCVector[i]->getBitRep();
         OHC_header.resize(totalLength);
-        result |= (OHC_header << ( OHCLength - i * 32));
+        result |= (OHC_header << (OHCLength - 32 - i * 32));
     }
     return result;
 

--- a/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/tlp_header.cpp
+++ b/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/utils/tlp_header.cpp
@@ -3,20 +3,23 @@
 
 boost::dynamic_bitset<> TLPHeader::getBitRep() const {
     int OHCLength = OHCVector.size() * 32;
-    boost::dynamic_bitset<> result(nonBase->headerSizeInBytes * 8 + OHCLength);
-
-    result |= ((boost::dynamic_bitset<>((nonBase->headerSizeInBytes * 8, (static_cast<int>(TLPtype) << ((nonBase->headerSizeInBytes * 8) - 8))))));
-    result |= ((boost::dynamic_bitset<>((nonBase->headerSizeInBytes * 8, TC)) << (nonBase->headerSizeInBytes * 8) - 11));
-    result |= ((boost::dynamic_bitset<>((nonBase->headerSizeInBytes * 8, OHC)) << ((nonBase->headerSizeInBytes * 8) - 16)));
+    int totalLength = nonBase->headerSizeInBytes * 8 + OHCLength;
+    boost::dynamic_bitset<> result (totalLength) ;
+    
+    result |= (boost::dynamic_bitset<>(totalLength, static_cast<int>(TLPtype))  << (totalLength - 8));
+    result |= (boost::dynamic_bitset<>(totalLength, TC) << (totalLength - 11));
+    result |= (boost::dynamic_bitset<>(totalLength, OHC) << (totalLength - 16));
     if (lengthInDoubleWord != 1024)
     {
-        result |= ((boost::dynamic_bitset<>(nonBase->headerSizeInBytes * 8, lengthInDoubleWord) << ((nonBase->headerSizeInBytes * 8) - 32)));
+        result |= ((boost::dynamic_bitset<>(totalLength, lengthInDoubleWord) << (totalLength - 32)));
     }
     boost::dynamic_bitset<> nonBaseHeader = nonBase->getBitRep();
-    result |= ((nonBaseHeader) << OHCLength);
+    nonBaseHeader.resize(totalLength);
+    result |= (nonBaseHeader << OHCLength);
     for (int i = 0; i < OHCVector.size(); i++) {
         boost::dynamic_bitset<> OHC_header = OHCVector[i]->getBitRep();
-        result |= (OHC_header << (OHCLength - i * 32));
+        OHC_header.resize(totalLength);
+        result |= (OHC_header << ( OHCLength - i * 32));
     }
     return result;
 


### PR DESCRIPTION
I only verified the header and TLP unit tests statically, but they might have some mistakes; this is because the header getBitRep function causes a runtime error that needs to be fixed.

Identified errors:
* In AddressRouting32 and AddressRouting64, the address needs to be shifted by 2 bits
* In CompletionNonHeaderBase, the lower address field is 5 bits, 4 bits are contiguous, and the 5th is alone on the second DW. The 5th bit is never set
![image](https://user-images.githubusercontent.com/57875312/235298901-a4cd52f1-3b75-4a50-a9bc-ec6de98d3c40.png)
* The getBitRep function of TLPHeader causes runtime errors, this is because it's to perform an OR operation on bitsets that are not of the same size. This needs investigation.
* Other errors may arise after fixing these errors