### PR TITLE
Change composed objects to references

### DIFF
--- a/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/layers/receiver.h
+++ b/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/layers/receiver.h
@@ -7,7 +7,7 @@
 
 class Receiver {
 public:
-	Globals globals;
+	Globals& globals;
 	LayersWrapper layers;
 	QueueWrapper<TLP*>& sendOn;
 

--- a/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/layers/transmitter.h
+++ b/PCIe 6.0 Packet Generator and Exerciser/PCIe 6.0 Packet Generator and Exerciser/layers/transmitter.h
@@ -18,7 +18,7 @@
  */
 class Transmitter {
 public:
-	Globals globals;
+	Globals& globals;
 	LayersWrapper* layers;
 	QueueWrapper<Flit*>* sendOn;
 


### PR DESCRIPTION
I was doing some system testing, and as it turns out, if there is composition like in Transmitter and Receiver here, if we don't add &, then a copy of the object is added, and not the original object.
This resulted in the Receiver modifying a Globals object, and the Transmitted reading another one, which led to infinite initialization